### PR TITLE
Add WebSocket streaming, auth backend, and layout fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
+## TradeChart
+
+Simple no-build React + Tailwind trading interface powered by Binance data and
+Lightweight Charts.
+
+### Development
+
+```bash
+npm install
+npm run dev    # serves the front-end
+npm run server # starts the auth API on http://localhost:3001
+```
+
+The auth API stores users in a local SQLite database (`data.db`).  It exposes
+`/api/register` and `/api/login` for basic username/password authentication.
+Tokens returned from these endpoints should be stored in `localStorage`.
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>TradeChart — Lightweight Trading Platform</title>
     <meta name="description" content="TradeChart: a lightweight, TradingView‑style charting and paper‑trading web app." />
     <script src="https://cdn.tailwindcss.com"></script>
@@ -19,14 +19,57 @@
         height: 100%;
         margin: 0;
         padding: 0;
-        overflow: hidden;
       }
-      .card { @apply rounded-2xl shadow-lg p-4 bg-white dark:bg-zinc-900 border border-zinc-100 dark:border-zinc-800; }
-      .btn { @apply rounded-xl px-3 py-2 border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800; }
-      .btn-primary { @apply bg-blue-600 text-white border-blue-600 hover:bg-blue-700; }
-      .input { @apply rounded-xl px-3 py-2 border w-full border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900; }
-      .select { @apply rounded-xl px-3 py-2 border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900; }
-      .label { @apply text-sm text-zinc-500 dark:text-zinc-400; }
+      html, body {
+        overflow-x: hidden;
+      }
+      .card {
+        border-radius: 1rem;
+        box-shadow: 0 10px 15px -3px rgba(0,0,0,0.1), 0 4px 6px -2px rgba(0,0,0,0.05);
+        padding: 1rem;
+        background-color: #ffffff;
+        border: 1px solid #f4f4f5;
+      }
+      .dark .card {
+        background-color: #18181b;
+        border-color: #27272a;
+      }
+      .btn,
+      .btn-primary {
+        border-radius: 0.75rem;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d4d4d8;
+        cursor: pointer;
+      }
+      .btn:hover { background-color: #f4f4f5; }
+      .dark .btn { border-color: #3f3f46; color: #e4e4e7; }
+      .dark .btn:hover { background-color: #27272a; }
+      .btn-primary {
+        background-color: #2563eb;
+        border-color: #2563eb;
+        color: #ffffff;
+      }
+      .btn-primary:hover { background-color: #1d4ed8; }
+      .input,
+      .select {
+        border-radius: 0.75rem;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid #d4d4d8;
+        background-color: #ffffff;
+        width: 100%;
+        color: #0a0a0a;
+      }
+      .dark .input,
+      .dark .select {
+        border-color: #3f3f46;
+        background-color: #18181b;
+        color: #e4e4e7;
+      }
+      .label {
+        font-size: 0.875rem;
+        color: #71717a;
+      }
+      .dark .label { color: #a1a1aa; }
       input::placeholder, select::placeholder {
         color: #a1a1aa;
       }

--- a/package.json
+++ b/package.json
@@ -5,16 +5,21 @@
   "description": "No-build React + Tailwind + Lightweight Charts trading app (CDN)",
   "scripts": {
     "dev": "npx serve .",
-    "lint": "echo 'no lint configured'"
+    "lint": "echo 'no lint configured'",
+    "server": "node server.js"
   },
   "main": "index.js",
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcrypt": "^5.1.1",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
     "lightweight-charts": "^5.0.8",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "@types/react": "^19.1.10",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,45 @@
+const express = require('express');
+const sqlite3 = require('sqlite3').verbose();
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+
+const app = express();
+const db = new sqlite3.Database('./data.db');
+
+// create users table if it doesn't exist
+db.run(`CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT UNIQUE,
+  password TEXT
+)`);
+
+app.use(express.json());
+
+const SECRET = 'change_me';
+
+app.post('/api/register', (req, res) => {
+  const { username, password } = req.body;
+  if (!username || !password) return res.status(400).json({ error: 'Missing fields' });
+  bcrypt.hash(password, 10, (err, hash) => {
+    if (err) return res.status(500).json({ error: 'Hashing failed' });
+    db.run('INSERT INTO users (username, password) VALUES (?,?)', [username, hash], function(err) {
+      if (err) return res.status(400).json({ error: 'User exists' });
+      const token = jwt.sign({ id: this.lastID, username }, SECRET);
+      res.json({ token });
+    });
+  });
+});
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  db.get('SELECT * FROM users WHERE username = ?', [username], (err, row) => {
+    if (err || !row) return res.status(400).json({ error: 'Invalid credentials' });
+    bcrypt.compare(password, row.password, (err, ok) => {
+      if (!ok) return res.status(400).json({ error: 'Invalid credentials' });
+      const token = jwt.sign({ id: row.id, username }, SECRET);
+      res.json({ token });
+    });
+  });
+});
+
+app.listen(3001, () => console.log('API server running on 3001'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,7 +84,7 @@ function RSI(data: Candle[], len = 14) {
 }
 
 // ---- Chart component ----
-function ChartPane({ data, overlays, theme }:{ data: Candle[], overlays: { sma?: number, ema?: number }, theme: 'light'|'dark' }) {
+function ChartPane({ symbol, tf, data, overlays, theme }:{ symbol:string, tf:string, data: Candle[], overlays: { sma?: number, ema?: number }, theme: 'light'|'dark' }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const volRef = useRef<HTMLDivElement | null>(null);
   const rsiRef = useRef<HTMLDivElement | null>(null);
@@ -105,9 +105,10 @@ function ChartPane({ data, overlays, theme }:{ data: Candle[], overlays: { sma?:
       rightPriceScale: { borderColor: theme === 'dark' ? '#3f3f46' : '#d4d4d8' },
       timeScale: { borderColor: theme === 'dark' ? '#3f3f46' : '#d4d4d8' }
     };
-    const chart = LightweightCharts.createChart(ref.current!, { height: 420, ...opts });
-    const volChart = LightweightCharts.createChart(volRef.current!, { height: 120, ...opts });
-    const rsiChart = LightweightCharts.createChart(rsiRef.current!, { height: 140, ...opts });
+    const w = ref.current!.clientWidth;
+    const chart = LightweightCharts.createChart(ref.current!, { width: w, height: 420, ...opts });
+    const volChart = LightweightCharts.createChart(volRef.current!, { width: w, height: 120, ...opts });
+    const rsiChart = LightweightCharts.createChart(rsiRef.current!, { width: w, height: 140, ...opts });
 
     chartRef.current = chart;
     volChartRef.current = volChart;
@@ -144,6 +145,9 @@ function ChartPane({ data, overlays, theme }:{ data: Candle[], overlays: { sma?:
     };
   }, [theme]);
 
+  const shouldFit = useRef(true);
+  useEffect(() => { shouldFit.current = true; }, [symbol, tf]);
+
   useEffect(() => {
     if (!data.length || !candleSeriesRef.current) return;
     candleSeriesRef.current.setData(data.map(d => ({ time: d.time, open: d.open, high: d.high, low: d.low, close: d.close })));
@@ -152,7 +156,10 @@ function ChartPane({ data, overlays, theme }:{ data: Candle[], overlays: { sma?:
     if (overlays.sma) smaSeriesRef.current?.setData(SMA(data, overlays.sma).map(d => ({ time: d.time, value: d.value })));
     if (overlays.ema) emaSeriesRef.current?.setData(EMA(data, overlays.ema).map(d => ({ time: d.time, value: d.value })));
     rsiSeriesRef.current?.setData(RSI(data, 14).map(d => ({ time: d.time, value: d.value })));
-    chartRef.current?.timeScale().fitContent();
+    if (shouldFit.current) {
+      chartRef.current?.timeScale().fitContent();
+      shouldFit.current = false;
+    }
   }, [data, overlays]);
 
   return (
@@ -166,8 +173,46 @@ function ChartPane({ data, overlays, theme }:{ data: Candle[], overlays: { sma?:
   );
 }
 
+function Auth({ onAuth }:{ onAuth:(t:string)=>void }) {
+  const [mode, setMode] = useState<'login'|'register'>('login');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [err, setErr] = useState<string|null>(null);
+  async function submit(e:any) {
+    e.preventDefault();
+    setErr(null);
+    try {
+      const res = await fetch(`/api/${mode}`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ username, password }) });
+      const js = await res.json();
+      if (!res.ok) throw new Error(js.error || 'Request failed');
+      onAuth(js.token);
+    } catch(e:any) { setErr(e.message); }
+  }
+  return (
+    <div className="h-full flex items-center justify-center">
+      <form onSubmit={submit} className="card w-80 space-y-3">
+        <h2 className="text-xl font-semibold">{mode==='login'?'Login':'Register'}</h2>
+        <input className="input" placeholder="Username" value={username} onChange={e=>setUsername(e.target.value)} />
+        <input type="password" className="input" placeholder="Password" value={password} onChange={e=>setPassword(e.target.value)} />
+        {err && <div className="text-sm text-red-500">{err}</div>}
+        <button className="btn-primary w-full" type="submit">{mode==='login'?'Login':'Register'}</button>
+        <div className="text-sm text-center">
+          {mode==='login' ? (
+            <button type="button" className="text-blue-500" onClick={()=>setMode('register')}>Need an account? Register</button>
+          ) : (
+            <button type="button" className="text-blue-500" onClick={()=>setMode('login')}>Have an account? Login</button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}
+
 // ---- Main App ----
 function App() {
+  const [token, setToken] = useState<string>(LS.get('tc.token', ''));
+  if (!token) return <Auth onAuth={t => { LS.set('tc.token', t); setToken(t); }} />;
+
   const [symbol, setSymbol] = useState(LS.get('tc.symbol', 'BTCUSDT'));
   const [tf, setTf] = useState(LS.get('tc.tf', '1h'));
   const [theme, setTheme] = useState<'light'|'dark'>(LS.get('tc.theme', 'dark'));
@@ -178,6 +223,7 @@ function App() {
   const [orders, setOrders] = useState<Order[]>(LS.get('tc.orders', []));
   const [positions, setPositions] = useState<Position[]>(LS.get('tc.pos', []));
   const [qty, setQty] = useState<number>(LS.get('tc.qty', 0.001));
+  const wsRef = useRef<WebSocket | null>(null);
 
   // persist
   useEffect(() => { LS.set('tc.symbol', symbol); }, [symbol]);
@@ -197,11 +243,36 @@ function App() {
     } catch(e:any) { setErr(e.message || 'Failed to load'); }
     finally { setLoading(false); }
   }
-  useEffect(() => { load(); }, [symbol, tf]);
-  // refresh every 15s
   useEffect(() => {
-    const id = setInterval(() => load(), 15000);
-    return () => clearInterval(id);
+    load();
+    const stream = `${symbol.toLowerCase()}@kline_${TF_TO_BINANCE[tf]}`;
+    const ws = new WebSocket(`wss://stream.binance.com:9443/ws/${stream}`);
+    wsRef.current = ws;
+    ws.onmessage = ev => {
+      const m = JSON.parse(ev.data);
+      if (!m.k) return;
+      const k = m.k;
+      const c: Candle = {
+        time: Math.floor(k.t / 1000),
+        open: parseFloat(k.o),
+        high: parseFloat(k.h),
+        low: parseFloat(k.l),
+        close: parseFloat(k.c),
+        volume: parseFloat(k.v)
+      };
+      setData(d => {
+        const copy = d.slice();
+        const last = copy[copy.length - 1];
+        if (last && last.time === c.time) {
+          copy[copy.length - 1] = c;
+        } else {
+          copy.push(c);
+          if (copy.length > 600) copy.shift();
+        }
+        return copy;
+      });
+    };
+    return () => ws.close();
   }, [symbol, tf]);
 
   const last = data.at(-1)?.close ?? 0;
@@ -265,10 +336,10 @@ function App() {
             <select className="select" value={tf} onChange={e => setTf(e.target.value)}>
               {Object.keys(TF).map(k => <option key={k} value={k}>{k}</option>)}
             </select>
-            <button className="btn" onClick={() => load()}>{isLoading ? 'Loading…' : 'Refresh'}</button>
           </div>
           <div className="ml-auto flex items-center gap-2">
             <button className="btn" onClick={() => setTheme(t => t === 'dark' ? 'light' : 'dark')}>{theme === 'dark' ? '🌙' : '☀️'}</button>
+            <button className="btn" onClick={() => { setToken(''); LS.set('tc.token',''); }}>Logout</button>
             <a className="btn" href="https://binance.com" target="_blank" rel="noreferrer">Data: Binance</a>
           </div>
         </div>
@@ -393,7 +464,7 @@ function App() {
                 {err && <span className="text-sm text-red-500">{String(err)}</span>}
               </div>
             </div>
-            <ChartPane data={data} overlays={{ sma: 20, ema: 50 }} theme={theme} />
+            <ChartPane symbol={symbol} tf={tf} data={data} overlays={{ sma: 20, ema: 50 }} theme={theme} />
           </div>
 
           <div className="text-sm text-zinc-500 dark:text-zinc-400">


### PR DESCRIPTION
## Summary
- Stream Binance candles over WebSockets for real-time chart updates and remove manual refresh
- Fix viewport overflow and initialize chart width to prevent horizontal stretch
- Add simple register/login UI with Express+SQLite backend and document setup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx tsc --noEmit` *(fails: 'React' refers to a UMD global, but the current file is a module...)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b8417460832988b2e37867b10439